### PR TITLE
fix(bambu): cloud filament endpoints moved to design-user-service (fixes #57)

### DIFF
--- a/filament_manager/backend/app/bambu_cloud_client.py
+++ b/filament_manager/backend/app/bambu_cloud_client.py
@@ -52,10 +52,17 @@ _2FA_TIMEOUT_SECONDS = 600  # 10 minutes
 
 _AUTH_BASE = "https://api.bambulab.com/v1/user-service/user"
 _IOT_BASE  = "https://api.bambulab.com/v1/iot-service/api"
+# Cloud filament library (my/filament/v2 + filament/config). Bambu moved these
+# off the user-service micro-service onto design-user-service (the MakerWorld
+# profile/preference service); the old /v1/user-service/my/filament/v2 now 404s.
+# Host + /v1/... + the /my/filament/v2 path tail + bearer auth are unchanged —
+# only the service segment changed (user-service -> design-user-service). Verified
+# against the reverse-engineered ClusterM/open-bamboo-networking cloud_filament.cpp
+# base_v2() and Doridian/OpenBambuAPI cloud-http.md.
 _FILAMENT_BASE: dict[str, str] = {
-    "us": "https://api.bambulab.com/v1/user-service",
-    "eu": "https://api.bambulab.com/v1/user-service",
-    "cn": "https://api.bambulab.cn/v1/user-service",
+    "us": "https://api.bambulab.com/v1/design-user-service",
+    "eu": "https://api.bambulab.com/v1/design-user-service",
+    "cn": "https://api.bambulab.cn/v1/design-user-service",
 }
 MQTT_HOSTS: dict[str, str] = {
     "us": "us.mqtt.bambulab.com",


### PR DESCRIPTION
## Problem (#57)
The cloud filament calls 404:
```
404 Client Error: Not Found for url:
https://api.bambulab.com/v1/user-service/my/filament/v2?offset=0&limit=50
```
Affects all five filament endpoints sharing `_FILAMENT_BASE` (`my/filament/v2` list/create/update, `my/filament/v2/batch` delete, `filament/config`).

## Root cause
Bambu **moved cloud filament management off the `user-service` micro-service onto `design-user-service`** (the MakerWorld profile/preference service). Host, `/v1/`, the `/my/filament/v2` path tail, and bearer auth are all unchanged — only the service segment moved.

```
OLD (404):  .../v1/user-service/my/filament/v2
NEW:        .../v1/design-user-service/my/filament/v2
                 ^^^^^^^------ only change
```

## Fix
`_FILAMENT_BASE` (us/eu/cn) → `…/v1/design-user-service`. Single dict feeds all five filament calls via `_filament_base()`; nothing else uses it, so this one change fixes the whole set. Fix-only — no version/config changes.

## Verification
- The replacement is publicly reverse-engineered and convergent across multiple independent projects; primary sources:
  - **ClusterM/open-bamboo-networking** `src/cloud_filament.cpp` — `base_v2()` → `<host>/v1/design-user-service/my/filament/v2` (from a MITM dump of the stock Bambu network plugin).
  - **Doridian/OpenBambuAPI** `cloud-http.md` — documents `GET /v1/design-user-service/my/filament/v2`.
  - **greghesp/pybambu** uses `design-user-service` for the sibling `my/preference`, confirming the service is real and active.
- **Live-validated:** a full cloud filament list (91 spools) now previews (HTTP 200) and imports cleanly with **no 404**, against a real Bambu Cloud account.

## Caveat (honest scope)
The **LIST/read path is fully validated.** The write-side request body field names (`CreateFilamentV2Req`/`UpdateFilamentV2Req`) are described by-shape in the reverse-engineering sources rather than field-by-field — the base-URL fix is correct for create/update/delete too, but if create/update misbehave that's a small follow-on on the body schema; list (the common case + sync import) is unaffected.

Fixes #57.