### PR TITLE
build: stop tsc from emitting compiled .js into frontend/src

### DIFF
--- a/filament_manager/frontend/src/.gitignore
+++ b/filament_manager/frontend/src/.gitignore
@@ -1,0 +1,10 @@
+# Compiled TypeScript output must never be committed.
+# The Docker image builds the frontend with `npm run build` (vite) from the
+# .tsx/.ts sources into dist/ — any .js/.d.ts sitting next to a source file is
+# stray `tsc` output (the build script runs `tsc && vite build`). tsconfig now
+# sets compilerOptions.noEmit, and this is a belt-and-suspenders guard so the
+# output can never be committed again.
+*.js
+*.jsx
+*.js.map
+*.d.ts

--- a/filament_manager/frontend/tsconfig.json
+++ b/filament_manager/frontend/tsconfig.json
@@ -9,7 +9,8 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noEmit": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
The build runs `tsc && vite build`; without `noEmit`, the `tsc` step emits .js/.d.ts next to sources. Those are never used (vite builds from source into dist/) and can get committed by accident. This sets `compilerOptions.noEmit=true` (tsc type-checks only) and adds a `frontend/src/.gitignore` guard. Build verified: `npm run build` succeeds and emits nothing into src/.