### PR TITLE
fix(sync): render Filament Sync review modal with a positioned overlay

### DIFF
--- a/filament_manager/frontend/src/components/SyncReviewModal.tsx
+++ b/filament_manager/frontend/src/components/SyncReviewModal.tsx
@@ -176,7 +176,11 @@ export default function SyncReviewModal({ syncMode, onClose }: Props) {
 
   return (
     <Modal>
-      <div className="flex flex-col" style={{ maxHeight: '85vh', width: 'min(680px, 96vw)' }}>
+      {/* Full-screen overlay + backdrop, matching the app's other modals. Without it the
+          portaled panel renders as an unpositioned in-flow block at the end of <body> —
+          i.e. below the fold / invisible (the modal mounts and works, it just never shows). */}
+      <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
+      <div className="flex flex-col bg-surface-2 border border-surface-3 rounded-2xl" style={{ maxHeight: '85vh', width: 'min(680px, 96vw)' }}>
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-gray-700 shrink-0">
           <div className="flex items-center gap-2">
@@ -438,6 +442,7 @@ export default function SyncReviewModal({ syncMode, onClose }: Props) {
             </>
           )}
         </div>
+      </div>
       </div>
     </Modal>
   )


### PR DESCRIPTION
## Problem

Clicking **Sync Now** (Settings → Filament Sync) appears to do nothing — no modal, deterministically on every browser and the native iOS Home Assistant app. The backend is fine (`POST /api/filament-sync/preview` returns 200 on the click) and the app doesn't crash.

## Root cause

`SyncReviewModal` is the **only** modal whose content is passed to the shared `Modal` wrapper as a bare panel:

```tsx
// Modal.tsx
export default function Modal({ children }) { return createPortal(children, document.body) }
```

`Modal` provides no positioning/backdrop of its own — every other modal supplies its own full-screen overlay internally (`fixed inset-0 … bg-black/60 flex items-center justify-center`). `SyncReviewModal`'s top-level child was just:

```tsx
<div className="flex flex-col" style={{ maxHeight: '85vh', width: 'min(680px, 96vw)' }}>
```

With no `fixed inset-0` wrapper, the portal appends the panel as an **unpositioned, in-flow block at the end of `<body>`** — so it renders below the fold / effectively invisible. The modal actually mounts and its preview fetch runs; it just never appears on screen.

## Fix

Wrap the panel in the same overlay the other modals use, and give the panel the standard card surface — no behavior change, purely the missing positioning:

```tsx
<div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
  <div className="flex flex-col bg-surface-2 border border-surface-3 rounded-2xl" style={{ … }}>
```

## Testing

- `npx tsc --noEmit` — clean
- `npx vite build` — succeeds (3110 modules)
- Only `SyncReviewModal.tsx` changed (source `.tsx` only; no compiled output committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)