### PR TITLE
fix(ui): show sync + audit timestamps in the HA timezone (not browser-local)

### DIFF
--- a/filament_manager/frontend/src/components/FilamentSyncSection.tsx
+++ b/filament_manager/frontend/src/components/FilamentSyncSection.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next'
 import { RefreshCw, ArrowDownToLine, ArrowUpFromLine, ArrowLeftRight, Ban } from 'lucide-react'
 import { api } from '../api'
 import type { SyncMode } from '../types'
+import { formatDateTimeTZ } from '../utils/time'
+import { useHATZ } from '../hooks/useHATZ'
 import SyncReviewModal from './SyncReviewModal'
 
 const MODES: { value: SyncMode; icon: React.ReactNode }[] = [
@@ -15,6 +17,7 @@ const MODES: { value: SyncMode; icon: React.ReactNode }[] = [
 
 export default function FilamentSyncSection({ isCloudConnected }: { isCloudConnected: boolean }) {
   const { t } = useTranslation()
+  const tz = useHATZ()
   const qc = useQueryClient()
   const [showModal, setShowModal] = useState(false)
 
@@ -78,7 +81,7 @@ export default function FilamentSyncSection({ isCloudConnected }: { isCloudConne
           {syncStatus.last_sync_at && (
             <span>
               {t('settings.filamentSync.lastSync', {
-                date: new Date(syncStatus.last_sync_at).toLocaleString(),
+                date: formatDateTimeTZ(syncStatus.last_sync_at, tz),
               })}
             </span>
           )}

--- a/filament_manager/frontend/src/pages/Spools.tsx
+++ b/filament_manager/frontend/src/pages/Spools.tsx
@@ -5,7 +5,8 @@ import { api } from '../api'
 import type { Spool, BrandSpoolWeight, FilamentCatalog, SpoolAuditEntry } from '../types'
 import { Plus, Pencil, Trash2, X, LayoutGrid, Table2, ChevronUp, ChevronDown, ChevronsUpDown, Copy, History, RotateCcw, Archive, ArchiveRestore, Columns3, Cloud } from 'lucide-react'
 import Modal from '../components/Modal'
-import { formatDateOnly } from '../utils/time'
+import { formatDateOnly, formatDateTimeTZ } from '../utils/time'
+import { useHATZ } from '../hooks/useHATZ'
 
 // ── Spool Form ────────────────────────────────────────────────────────────────
 
@@ -429,6 +430,8 @@ function SpoolAuditModal({ spool, onClose }: { spool: Spool; onClose: () => void
     },
   })
 
+  const tz = useHATZ()
+
   const actionLabel = (action: string) => t(`spools.audit.action_${action}`, action)
 
   const handleCorrect = (e: SpoolAuditEntry) => {
@@ -473,7 +476,7 @@ function SpoolAuditModal({ spool, onClose }: { spool: Spool; onClose: () => void
                   return (
                     <tr key={e.id} className="border-b border-surface-3/40 hover:bg-surface-3/30">
                       <td className="px-4 py-2 text-gray-400 whitespace-nowrap">
-                        {new Date(e.changed_at).toLocaleString()}
+                        {formatDateTimeTZ(e.changed_at, tz)}
                       </td>
                       <td className="px-4 py-2 whitespace-nowrap">
                         <span className={`px-1.5 py-0.5 rounded text-xs ${


### PR DESCRIPTION
## Problem

The Filament Sync status line ("Last sync: …") displays a time **shifted into the future** by the viewer's UTC offset — e.g. ~7h ahead for a UTC−7 user. The spool weight-history ("audit") modal has the same issue on its `changed_at` column.

## Root cause

Backend timestamps are **naive UTC** (no `Z`/offset suffix) — this is intentional and documented in `utils/time.ts`:

> `All timestamps from the backend are naive UTC (no 'Z' suffix). parseUTC() forces correct UTC interpretation before formatting.`

Two spots bypassed that helper and formatted the raw string directly:

```tsx
new Date(syncStatus.last_sync_at).toLocaleString()   // FilamentSyncSection
new Date(e.changed_at).toLocaleString()              // Spools SpoolAuditModal
```

`new Date("2026-07-03T07:48:11")` (no offset) is parsed as **local** time, so the displayed value is off by the local UTC offset.

## Fix

Use the existing `formatDateTimeTZ(iso, tz)` helper (it runs `parseUTC()` first) with the HA-configured timezone from `useHATZ()` — the exact pattern `Prints`/`Projects` already use for `started_at`. No backend change: naive-UTC emission is relied on throughout, and `utils/time` is the canonical place the frontend compensates.

## Testing

- `npx tsc --noEmit` — clean
- `npx vite build` — succeeds
- Source `.tsx` only; no compiled output committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)