### PR TITLE
feat(ams): auto-bind spool to tray via RFID tag_uid (deterministic auto-deduct on load)

### DIFF
--- a/filament_manager/backend/app/ams_autobind.py
+++ b/filament_manager/backend/app/ams_autobind.py
@@ -1,0 +1,212 @@
+"""
+Smart auto-bind of tracked spools to AMS trays via RFID ``tag_uid``.
+
+When a genuine Bambu spool is physically loaded into an AMS tray, the printer
+reads its RFID ``tag_uid`` — a 16-hex string that is unique per physical spool.
+This module uses that tag to deterministically bind the tracked :class:`Spool`
+to the tray by setting the spool's ``ams_slot`` column, so the *existing*
+auto-deduct logic (see ``print_monitor``) fires against the correct physical
+spool even when the user owns many spools of the same material + colour.
+
+``ams_slot`` is stored in the ``"{printer_name}:{slot_key}"`` form (see
+``routers/printers.py``) — this module writes that same full-key form.
+
+SAFETY — never auto-bind ambiguously
+------------------------------------
+The only auto-actions taken here are:
+
+  (a) deterministic re-bind: a tag_uid we've already bound to a spool re-appears
+      in a tray → move that spool's ams_slot to the current tray, and
+  (b) single-unambiguous first bind: a never-seen tag_uid whose material+colour
+      (or bambu_spool_id+colour) matches EXACTLY ONE not-yet-tag-bound spool.
+
+Zero or multiple candidates → we do nothing and leave the tray for a one-time
+manual "Assign spool" confirm in the UI (which then stores the tag_uid via the
+assign endpoint, upgrading it to case (a) for all future loads).
+
+This guarantees auto-deduct can never deduct from the wrong physical spool even
+if this feature ships before review.
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from .database import SessionLocal
+from .models import PrinterConfig, Spool
+
+log = logging.getLogger(__name__)
+
+
+def _is_real_tag_uid(tag_uid) -> bool:
+    """True only for a usable RFID tag.
+
+    Genuine Bambu spools report a 16-hex, non-zero value (e.g.
+    ``"4767E20300000100"``). Third-party/generic spools report empty or
+    all-zeros (``"0000000000000000"``) — those have no usable RFID and are
+    skipped entirely (manual assignment only).
+    """
+    if not tag_uid:
+        return False
+    s = str(tag_uid).strip()
+    if not s:
+        return False
+    # All-zeros (any length) = no tag present.
+    if set(s) <= {"0"}:
+        return False
+    return True
+
+
+def _find_first_bind_candidate(db: Session, slot_info: dict) -> Spool | None:
+    """Find the single unambiguous spool to first-bind to a tray.
+
+    Match among spools that are NOT already tag_uid-bound, by:
+      1. (bambu_spool_id AND colour) when the tray carries a bambu_spool_id, else
+      2. (material AND colour).
+
+    Colour comes from the AMS tray cache as ``"#RRGGBB"``; we compare
+    case-insensitively against the spool's ``color_hex``. Returns the spool only
+    when EXACTLY ONE candidate matches; ``None`` for zero or multiple.
+    """
+    material = (slot_info.get("material") or "").strip()
+    color = (slot_info.get("color") or "").strip()
+    bambu_spool_id = slot_info.get("bambu_spool_id")
+
+    if not color:
+        return None  # colour is required for a safe first bind
+
+    # Only consider spools that have some stock left and are not archived — a
+    # physically loaded spool is an active one.
+    base = (
+        db.query(Spool)
+        .filter(Spool.tag_uid.is_(None))
+        .filter(Spool.archived == False)  # noqa: E712
+        .filter(Spool.current_weight_g > 0)
+    )
+
+    def _by_color(q):
+        # Case-insensitive hex compare (SQLite LIKE is case-insensitive for ASCII).
+        return q.filter(Spool.color_hex.ilike(color))
+
+    candidates: list[Spool] = []
+    if bambu_spool_id:
+        candidates = _by_color(
+            base.filter(Spool.bambu_spool_id == str(bambu_spool_id))
+        ).all()
+    if not candidates and material:
+        candidates = _by_color(base.filter(Spool.material == material)).all()
+
+    if len(candidates) == 1:
+        return candidates[0]
+    return None
+
+
+def _clear_slot_from_others(db: Session, full_key: str, slot_key: str, keep_spool_id: int | None) -> None:
+    """Ensure no OTHER spool claims this AMS slot (a tray holds one spool).
+
+    Clears ``ams_slot`` from every spool currently pointing at this slot
+    (either full ``"{printer}:{slot}"`` or bare ``slot`` form) except the one we
+    are binding. Guards against duplicate binds / races.
+    """
+    q = db.query(Spool).filter(
+        (Spool.ams_slot == full_key) | (Spool.ams_slot == slot_key)
+    )
+    if keep_spool_id is not None:
+        q = q.filter(Spool.id != keep_spool_id)
+    q.update({"ams_slot": None}, synchronize_session=False)
+
+
+def _autobind_for_printer(db: Session, printer: PrinterConfig, detail: dict[str, dict]) -> int:
+    """Run the auto-bind pass for one printer's current AMS tray detail.
+
+    ``detail`` is ``{slot_key: {material, color, remain, tag_uid, ...}}`` from
+    ``bambu_cloud_client.get_ams_detail_for_serial``. Returns the number of
+    spools whose ams_slot was set/updated.
+    """
+    changed = 0
+    for slot_key, slot_info in detail.items():
+        tag_uid = slot_info.get("tag_uid")
+        if not _is_real_tag_uid(tag_uid):
+            continue  # empty / all-zeros / third-party → manual only
+        tag_uid = str(tag_uid).strip()
+        full_key = f"{printer.name}:{slot_key}"
+
+        # (a) Deterministic re-bind: this physical spool is already known.
+        bound = db.query(Spool).filter(Spool.tag_uid == tag_uid).first()
+        if bound is not None:
+            if bound.ams_slot != full_key:
+                _clear_slot_from_others(db, full_key, slot_key, keep_spool_id=bound.id)
+                log.info(
+                    "AMS auto-bind: tag_uid %s → spool #%d re-bound %s → %s",
+                    tag_uid, bound.id, bound.ams_slot, full_key,
+                )
+                bound.ams_slot = full_key
+                changed += 1
+            continue
+
+        # (b) First bind: never-seen tag_uid → single unambiguous candidate only.
+        candidate = _find_first_bind_candidate(db, slot_info)
+        if candidate is None:
+            continue  # zero or multiple → leave for manual assignment
+        _clear_slot_from_others(db, full_key, slot_key, keep_spool_id=candidate.id)
+        candidate.tag_uid = tag_uid
+        candidate.ams_slot = full_key
+        changed += 1
+        log.info(
+            "AMS auto-bind: first bind tag_uid %s → spool #%d (%s %s %s) at %s",
+            tag_uid, candidate.id, candidate.brand, candidate.material,
+            candidate.color_name, full_key,
+        )
+
+    return changed
+
+
+def autobind_from_ams_cache(serial: str) -> int:
+    """Entry point: reconcile spool↔tray binding from the live AMS cache.
+
+    Called from the MQTT message path whenever AMS tray data is refreshed. Opens
+    its own DB session (this runs on the paho MQTT thread, not the async loop).
+    Returns the number of spools re-bound/bound (0 if nothing to do).
+    Never raises — logs and returns 0 on any error.
+    """
+    try:
+        from . import bambu_cloud_client
+    except Exception:  # pragma: no cover — import guard
+        return 0
+
+    detail = bambu_cloud_client.get_ams_detail_for_serial(serial)
+    if not detail:
+        return 0
+    # Cheap pre-check: skip the DB session entirely if no tray has a real tag.
+    if not any(_is_real_tag_uid(s.get("tag_uid")) for s in detail.values()):
+        return 0
+
+    db = SessionLocal()
+    try:
+        printers = (
+            db.query(PrinterConfig)
+            .filter(PrinterConfig.bambu_serial == serial)
+            .filter(PrinterConfig.is_active == True)  # noqa: E712
+            .all()
+        )
+        total = 0
+        for printer in printers:
+            total += _autobind_for_printer(db, printer, detail)
+        if total:
+            db.commit()
+            try:
+                from . import ha_publisher
+                ha_publisher.trigger()
+            except Exception as exc:  # pragma: no cover
+                log.debug("AMS auto-bind: ha_publisher.trigger failed: %s", exc)
+        return total
+    except Exception as exc:
+        log.warning("AMS auto-bind failed for serial %s: %s", serial, exc, exc_info=True)
+        try:
+            db.rollback()
+        except Exception:
+            pass
+        return 0
+    finally:
+        db.close()

--- a/filament_manager/backend/app/ams_autobind.py
+++ b/filament_manager/backend/app/ams_autobind.py
@@ -11,21 +11,21 @@ spool even when the user owns many spools of the same material + colour.
 ``ams_slot`` is stored in the ``"{printer_name}:{slot_key}"`` form (see
 ``routers/printers.py``) — this module writes that same full-key form.
 
-SAFETY — never auto-bind ambiguously
-------------------------------------
-The only auto-actions taken here are:
+SAFETY — EXACT RFID identity only, never guess
+-----------------------------------------------
+The only auto-action taken here is a deterministic bind by physical RFID: a
+tray's real ``tag_uid`` is matched against ``Spool.tag_uid`` and, on an EXACT
+hit, that spool's ``ams_slot`` is moved to the current tray. A spool's
+``tag_uid`` is populated from the authoritative Bambu Cloud filament record
+during sync (see ``routers/filament_sync``) or via the manual "Assign spool"
+action in the UI.
 
-  (a) deterministic re-bind: a tag_uid we've already bound to a spool re-appears
-      in a tray → move that spool's ams_slot to the current tray, and
-  (b) single-unambiguous first bind: a never-seen tag_uid whose material+colour
-      (or bambu_spool_id+colour) matches EXACTLY ONE not-yet-tag-bound spool.
-
-Zero or multiple candidates → we do nothing and leave the tray for a one-time
-manual "Assign spool" confirm in the UI (which then stores the tag_uid via the
-assign endpoint, upgrading it to case (a) for all future loads).
-
-This guarantees auto-deduct can never deduct from the wrong physical spool even
-if this feature ships before review.
+We NEVER bind by material / colour / bambu_spool_id — those identify a
+*product*, not a *physical spool*, so guessing by them can (and did) stamp a
+tray's RFID onto the wrong record and deduct from the wrong spool. An unknown
+tag (no spool carries it) is left untouched for a one-time manual "Assign
+spool" confirm, which stores the tag_uid and upgrades all future loads to the
+exact-match path.
 """
 from __future__ import annotations
 
@@ -58,50 +58,6 @@ def _is_real_tag_uid(tag_uid) -> bool:
     return True
 
 
-def _find_first_bind_candidate(db: Session, slot_info: dict) -> Spool | None:
-    """Find the single unambiguous spool to first-bind to a tray.
-
-    Match among spools that are NOT already tag_uid-bound, by:
-      1. (bambu_spool_id AND colour) when the tray carries a bambu_spool_id, else
-      2. (material AND colour).
-
-    Colour comes from the AMS tray cache as ``"#RRGGBB"``; we compare
-    case-insensitively against the spool's ``color_hex``. Returns the spool only
-    when EXACTLY ONE candidate matches; ``None`` for zero or multiple.
-    """
-    material = (slot_info.get("material") or "").strip()
-    color = (slot_info.get("color") or "").strip()
-    bambu_spool_id = slot_info.get("bambu_spool_id")
-
-    if not color:
-        return None  # colour is required for a safe first bind
-
-    # Only consider spools that have some stock left and are not archived — a
-    # physically loaded spool is an active one.
-    base = (
-        db.query(Spool)
-        .filter(Spool.tag_uid.is_(None))
-        .filter(Spool.archived == False)  # noqa: E712
-        .filter(Spool.current_weight_g > 0)
-    )
-
-    def _by_color(q):
-        # Case-insensitive hex compare (SQLite LIKE is case-insensitive for ASCII).
-        return q.filter(Spool.color_hex.ilike(color))
-
-    candidates: list[Spool] = []
-    if bambu_spool_id:
-        candidates = _by_color(
-            base.filter(Spool.bambu_spool_id == str(bambu_spool_id))
-        ).all()
-    if not candidates and material:
-        candidates = _by_color(base.filter(Spool.material == material)).all()
-
-    if len(candidates) == 1:
-        return candidates[0]
-    return None
-
-
 def _clear_slot_from_others(db: Session, full_key: str, slot_key: str, keep_spool_id: int | None) -> None:
     """Ensure no OTHER spool claims this AMS slot (a tray holds one spool).
 
@@ -132,32 +88,21 @@ def _autobind_for_printer(db: Session, printer: PrinterConfig, detail: dict[str,
         tag_uid = str(tag_uid).strip()
         full_key = f"{printer.name}:{slot_key}"
 
-        # (a) Deterministic re-bind: this physical spool is already known.
+        # Exact RFID identity match ONLY. The spool's tag_uid is populated from
+        # the authoritative Bambu Cloud filament record during sync (see
+        # routers/filament_sync) or via the manual "Assign spool" action — never
+        # guessed from material/colour, which is a product, not a physical spool.
         bound = db.query(Spool).filter(Spool.tag_uid == tag_uid).first()
-        if bound is not None:
-            if bound.ams_slot != full_key:
-                _clear_slot_from_others(db, full_key, slot_key, keep_spool_id=bound.id)
-                log.info(
-                    "AMS auto-bind: tag_uid %s → spool #%d re-bound %s → %s",
-                    tag_uid, bound.id, bound.ams_slot, full_key,
-                )
-                bound.ams_slot = full_key
-                changed += 1
-            continue
-
-        # (b) First bind: never-seen tag_uid → single unambiguous candidate only.
-        candidate = _find_first_bind_candidate(db, slot_info)
-        if candidate is None:
-            continue  # zero or multiple → leave for manual assignment
-        _clear_slot_from_others(db, full_key, slot_key, keep_spool_id=candidate.id)
-        candidate.tag_uid = tag_uid
-        candidate.ams_slot = full_key
-        changed += 1
-        log.info(
-            "AMS auto-bind: first bind tag_uid %s → spool #%d (%s %s %s) at %s",
-            tag_uid, candidate.id, candidate.brand, candidate.material,
-            candidate.color_name, full_key,
-        )
+        if bound is None:
+            continue  # unknown physical spool → leave for manual "Assign spool"
+        if bound.ams_slot != full_key:
+            _clear_slot_from_others(db, full_key, slot_key, keep_spool_id=bound.id)
+            log.info(
+                "AMS auto-bind: tag_uid %s → spool #%d re-bound %s → %s",
+                tag_uid, bound.id, bound.ams_slot, full_key,
+            )
+            bound.ams_slot = full_key
+            changed += 1
 
     return changed
 

--- a/filament_manager/backend/app/bambu_cloud_client.py
+++ b/filament_manager/backend/app/bambu_cloud_client.py
@@ -536,9 +536,12 @@ def _process_device_message(serial: str, data: dict) -> None:
     # Update AMS cache from top-level or nested ams object
     # tray_now (currently active tray slot) lives inside the ams dict, not in print
     current = _printer_status_cache.get(serial, {})
+    ams_trays_seen = False
     for ams_source in (data.get("ams", {}), print_data.get("ams", {})):
         if ams_source:
             _parse_ams_into_cache(serial, ams_source)
+            if ams_source.get("ams"):
+                ams_trays_seen = True
             if "tray_now" in ams_source:
                 tray_now_val = ams_source["tray_now"]
                 current["tray_now"] = tray_now_val
@@ -564,6 +567,18 @@ def _process_device_message(serial: str, data: dict) -> None:
                 except (TypeError, ValueError):
                     pass
     _printer_status_cache[serial] = current
+
+    # RFID auto-bind: whenever fresh AMS tray data arrives (a spool was loaded /
+    # the tray profile changed), reconcile spool↔tray binding by physical
+    # tag_uid so the existing auto-deduct fires against the right spool. Runs on
+    # this MQTT thread with its own DB session; cheap-exits when no tray carries
+    # a real tag_uid. Never raises.
+    if ams_trays_seen:
+        try:
+            from . import ams_autobind
+            ams_autobind.autobind_from_ams_cache(serial)
+        except Exception as exc:
+            log.debug("AMS auto-bind hook failed for %s: %s", serial, exc)
 
     # Merge ALL scalar fields from the print object — Bambu sends incremental
     # updates so we only overwrite keys that are present in this message.
@@ -664,6 +679,13 @@ def _parse_ams_into_cache(serial: str, ams_raw: dict) -> None:
             base_type = tray.get("tray_type") or tray.get("type") or ""
             if sub_brand or base_type:
                 slot["material"] = sub_brand or base_type
+
+            # tag_uid — physical RFID tag of the loaded spool (16-hex, unique per
+            # genuine Bambu spool). Update only when present. Genuine spools send a
+            # real value; third-party/generic spools send "" or all-zeros. Preserve
+            # the last-seen value across incremental updates that omit the field.
+            if "tag_uid" in tray:
+                slot["tag_uid"] = tray["tag_uid"]
 
             existing[slot_key] = slot
             changed = True

--- a/filament_manager/backend/app/main.py
+++ b/filament_manager/backend/app/main.py
@@ -97,6 +97,15 @@ async def lifespan(app: FastAPI):
             conn.commit()
             log.info("Migration: added spools.archived")
 
+        # spools: add tag_uid (physical RFID tag_uid for AMS auto-bind) if missing
+        if "tag_uid" not in spool_cols:
+            conn.execute(text("ALTER TABLE spools ADD COLUMN tag_uid TEXT"))
+            conn.commit()
+            log.info("Migration: added spools.tag_uid")
+        # spools: index on tag_uid (matches models.Spool.tag_uid index=True) — guarded
+        conn.execute(text("CREATE INDEX IF NOT EXISTS ix_spools_tag_uid ON spools (tag_uid)"))
+        conn.commit()
+
         # printer_configs: rebuild to cloud-only schema (removes all greghesp HA columns)
         printer_cols = [c["name"] for c in insp.get_columns("printer_configs")]
         _ha_cols = {"device_slug", "ams_device_slug", "sensor_print_stage",

--- a/filament_manager/backend/app/models.py
+++ b/filament_manager/backend/app/models.py
@@ -49,6 +49,11 @@ class Spool(Base):
     article_number = Column(String, nullable=True)
     last_dried_at = Column(DateTime, nullable=True)
     ams_slot = Column(String)
+    # Physical RFID tag_uid read from the AMS tray (16-hex, unique per genuine
+    # Bambu spool). Once bound, future loads of the same physical spool are
+    # auto-detected → deterministic auto-deduct. Third-party spools report empty
+    # / all-zeros and are never bound here.
+    tag_uid = Column(String, nullable=True, index=True)
     bambu_spool_id = Column(String, nullable=True)   # Bambu Cloud filament spool ID (int64 stored as str)
     bambu_synced_at = Column(DateTime, nullable=True)  # last successful Bambu sync timestamp
     notes = Column(Text)

--- a/filament_manager/backend/app/routers/bambu_cloud.py
+++ b/filament_manager/backend/app/routers/bambu_cloud.py
@@ -147,6 +147,17 @@ async def get_tasks_raw(serial: str) -> dict:
     return {"serial": serial, "total": len(tasks), "tasks": tasks}
 
 
+@router.get("/filaments-raw")
+async def get_filaments_raw(limit: int = 5) -> dict:
+    """Debug: inspect raw Bambu Cloud filament records to confirm which key (if
+    any) carries the physical RFID tag_uid, and whether the cloud provides it at
+    all. Returns the total record count, the union of all keys seen across
+    records, and up to ``limit`` sample records verbatim."""
+    cloud_spools = await bambu_cloud_client.list_all_filaments()
+    keys = sorted({k for c in cloud_spools for k in c.keys()})
+    return {"total": len(cloud_spools), "keys": keys, "sample": cloud_spools[: max(0, limit)]}
+
+
 @router.post("/reconnect")
 async def force_reconnect() -> dict:
     """Force restart of all MQTT connections using saved credentials."""

--- a/filament_manager/backend/app/routers/filament_sync.py
+++ b/filament_manager/backend/app/routers/filament_sync.py
@@ -187,24 +187,20 @@ def _bind_ams_slots_from_cloud(db: Session, cloud_by_id: dict[str, dict]) -> Non
     """Set ``ams_slot`` on linked spools directly from the cloud AMS position.
 
     Deterministic and RFID-free: the cloud is authoritative for which tray each
-    spool sits in. We can only attribute a slot to a printer when there is
-    exactly ONE active printer (the cloud filament record does not name the
-    device); with several we skip rather than guess — never bind ambiguously.
+    spool sits in AND names the owning printer via ``devId`` (the printer
+    serial). Each in-printer spool is attributed to the tracked printer whose
+    ``bambu_serial`` matches ``devId`` — precise even across multiple printers; a
+    spool loaded on an untracked printer is skipped, never bound ambiguously.
     """
-    active = (
-        db.query(PrinterConfig)
+    printers_by_serial = {
+        p.bambu_serial: p
+        for p in db.query(PrinterConfig)
         .filter(PrinterConfig.is_active == True)  # noqa: E712
         .all()
-    )
-    if len(active) != 1:
-        if active:
-            log.info(
-                "filament sync: %d active printers — skipping cloud-AMS slot bind "
-                "(cloud record does not name the device); manual assign only",
-                len(active),
-            )
+        if p.bambu_serial
+    }
+    if not printers_by_serial:
         return
-    printer = active[0]
 
     for spool in db.query(Spool).filter(Spool.bambu_spool_id.isnot(None)).all():
         cloud = cloud_by_id.get(spool.bambu_spool_id)
@@ -213,6 +209,9 @@ def _bind_ams_slots_from_cloud(db: Session, cloud_by_id: dict[str, dict]) -> Non
         slot_key = _cloud_ams_slot_key(cloud)
         if slot_key is None:
             continue
+        printer = printers_by_serial.get(str(cloud.get("devId") or ""))
+        if printer is None:
+            continue  # spool loaded on a printer we don't track → skip
         full_key = f"{printer.name}:{slot_key}"
         if spool.ams_slot == full_key:
             continue

--- a/filament_manager/backend/app/routers/filament_sync.py
+++ b/filament_manager/backend/app/routers/filament_sync.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..database import get_db, SessionLocal
-from ..models import Spool, UserPreferences
+from ..models import PrinterConfig, Spool, UserPreferences
 from .. import bambu_cloud_client
 
 log = logging.getLogger(__name__)
@@ -158,31 +158,74 @@ def _local_to_cloud_body(spool: Spool) -> dict:
     }
 
 
-# ── Cloud RFID capture ──────────────────────────────────────────────────────────
+# ── Cloud AMS slot binding ───────────────────────────────────────────────────────
 
-# Bambu Cloud's field name for a spool's physical RFID tag_uid is unconfirmed and
-# has varied across API versions, so we probe several candidate keys (inspect the
-# live shape via GET /api/bambu-cloud/filaments-raw). First non-empty, non-all-zeros
-# wins. Capturing this onto Spool.tag_uid is what lets AMS auto-bind match a loaded
-# tray to the right physical spool by EXACT RFID — no material/colour guessing.
-_RFID_KEYS = ("rfid", "tagUid", "tag_uid", "filamentTagUid", "tray_uid", "RFID")
+def _cloud_ams_slot_key(rec: dict) -> str | None:
+    """Map a cloud filament record's AMS position to the addon slot_key form.
 
-
-def _extract_cloud_tag_uid(cloud: dict) -> str | None:
-    """Best-effort pull of a physical RFID tag_uid from a cloud filament record.
-
-    Returns a cleaned string, or ``None`` for empty / all-zeros / absent (mirrors
-    ams_autobind._is_real_tag_uid so we never store a non-identifying tag).
+    Bambu Cloud marks a spool physically loaded in an AMS tray with
+    ``inPrinter`` truthy plus 0-based ``amsId``/``slotId``. The addon's tray
+    cache keys slots as ``"ams{unit}_tray{tray}"`` with both 1-based and the
+    254/255 sentinels (external/virtual spool) filtered — see
+    ``bambu_cloud_client._parse_ams_into_cache``. We reproduce that exactly so a
+    cloud-derived slot_key matches the tray cache. Returns ``None`` when the
+    spool is not in a printer or the ids are sentinels/unparseable.
     """
-    for key in _RFID_KEYS:
-        val = cloud.get(key)
-        if val is None:
+    if not rec.get("inPrinter"):
+        return None
+    try:
+        ams_id = int(rec.get("amsId"))
+        slot_id = int(rec.get("slotId"))
+    except (TypeError, ValueError):
+        return None
+    if ams_id in (254, 255) or slot_id in (254, 255):
+        return None
+    return f"ams{ams_id + 1}_tray{slot_id + 1}"
+
+
+def _bind_ams_slots_from_cloud(db: Session, cloud_by_id: dict[str, dict]) -> None:
+    """Set ``ams_slot`` on linked spools directly from the cloud AMS position.
+
+    Deterministic and RFID-free: the cloud is authoritative for which tray each
+    spool sits in. We can only attribute a slot to a printer when there is
+    exactly ONE active printer (the cloud filament record does not name the
+    device); with several we skip rather than guess — never bind ambiguously.
+    """
+    active = (
+        db.query(PrinterConfig)
+        .filter(PrinterConfig.is_active == True)  # noqa: E712
+        .all()
+    )
+    if len(active) != 1:
+        if active:
+            log.info(
+                "filament sync: %d active printers — skipping cloud-AMS slot bind "
+                "(cloud record does not name the device); manual assign only",
+                len(active),
+            )
+        return
+    printer = active[0]
+
+    for spool in db.query(Spool).filter(Spool.bambu_spool_id.isnot(None)).all():
+        cloud = cloud_by_id.get(spool.bambu_spool_id)
+        if not cloud:
             continue
-        s = str(val).strip()
-        if not s or set(s) <= {"0"}:
+        slot_key = _cloud_ams_slot_key(cloud)
+        if slot_key is None:
             continue
-        return s
-    return None
+        full_key = f"{printer.name}:{slot_key}"
+        if spool.ams_slot == full_key:
+            continue
+        # One physical spool per slot — clear any other spool claiming it.
+        db.query(Spool).filter(
+            ((Spool.ams_slot == full_key) | (Spool.ams_slot == slot_key)),
+            Spool.id != spool.id,
+        ).update({"ams_slot": None}, synchronize_session=False)
+        log.info(
+            "filament sync: cloud-AMS bind spool #%d → %s (was %s)",
+            spool.id, full_key, spool.ams_slot,
+        )
+        spool.ams_slot = full_key
 
 
 # ── Match scoring ──────────────────────────────────────────────────────────────
@@ -548,24 +591,15 @@ async def apply_sync(body: ApplySyncRequest, db: Session = Depends(get_db)):
             log.warning("apply: import error for cloud=%s: %s", cloud_id, exc)
             errors += 1
 
-    # 2b. Backfill the physical RFID tag_uid from the authoritative cloud record
-    #     onto every linked spool missing it (just-matched, just-imported, and any
-    #     previously-linked spool). This is what makes AMS auto-bind automatic: the
-    #     record self-identifies by exact RFID, so no manual "Assign spool" tap is
-    #     needed once the cloud provides the tag.
+    # 2b. Bind ams_slot directly from the AUTHORITATIVE cloud AMS position.
+    #     Bambu Cloud reports which AMS slot each loaded spool occupies
+    #     (inPrinter + amsId + slotId); binding straight from that is fully
+    #     deterministic and needs no RFID/tag matching. We only know WHICH
+    #     printer's AMS it is when exactly one active printer exists (the cloud
+    #     filament record doesn't name the device) — with multiple printers we
+    #     SKIP rather than guess: never bind ambiguously.
     db.flush()  # ensure just-imported spools are queryable below
-    for spool in (
-        db.query(Spool)
-        .filter(Spool.bambu_spool_id.isnot(None))
-        .filter(Spool.tag_uid.is_(None))
-        .all()
-    ):
-        cloud = cloud_by_id.get(spool.bambu_spool_id)
-        if not cloud:
-            continue
-        tag = _extract_cloud_tag_uid(cloud)
-        if tag:
-            spool.tag_uid = tag
+    _bind_ams_slots_from_cloud(db, cloud_by_id)
 
     # 3. Push local → cloud (create cloud records for local-only spools)
     for local_id in body.push_to_cloud:

--- a/filament_manager/backend/app/routers/filament_sync.py
+++ b/filament_manager/backend/app/routers/filament_sync.py
@@ -158,6 +158,33 @@ def _local_to_cloud_body(spool: Spool) -> dict:
     }
 
 
+# ── Cloud RFID capture ──────────────────────────────────────────────────────────
+
+# Bambu Cloud's field name for a spool's physical RFID tag_uid is unconfirmed and
+# has varied across API versions, so we probe several candidate keys (inspect the
+# live shape via GET /api/bambu-cloud/filaments-raw). First non-empty, non-all-zeros
+# wins. Capturing this onto Spool.tag_uid is what lets AMS auto-bind match a loaded
+# tray to the right physical spool by EXACT RFID — no material/colour guessing.
+_RFID_KEYS = ("rfid", "tagUid", "tag_uid", "filamentTagUid", "tray_uid", "RFID")
+
+
+def _extract_cloud_tag_uid(cloud: dict) -> str | None:
+    """Best-effort pull of a physical RFID tag_uid from a cloud filament record.
+
+    Returns a cleaned string, or ``None`` for empty / all-zeros / absent (mirrors
+    ams_autobind._is_real_tag_uid so we never store a non-identifying tag).
+    """
+    for key in _RFID_KEYS:
+        val = cloud.get(key)
+        if val is None:
+            continue
+        s = str(val).strip()
+        if not s or set(s) <= {"0"}:
+            continue
+        return s
+    return None
+
+
 # ── Match scoring ──────────────────────────────────────────────────────────────
 
 def _match_score(local: Spool, cloud: dict) -> tuple[int, str]:
@@ -520,6 +547,25 @@ async def apply_sync(body: ApplySyncRequest, db: Session = Depends(get_db)):
         except Exception as exc:
             log.warning("apply: import error for cloud=%s: %s", cloud_id, exc)
             errors += 1
+
+    # 2b. Backfill the physical RFID tag_uid from the authoritative cloud record
+    #     onto every linked spool missing it (just-matched, just-imported, and any
+    #     previously-linked spool). This is what makes AMS auto-bind automatic: the
+    #     record self-identifies by exact RFID, so no manual "Assign spool" tap is
+    #     needed once the cloud provides the tag.
+    db.flush()  # ensure just-imported spools are queryable below
+    for spool in (
+        db.query(Spool)
+        .filter(Spool.bambu_spool_id.isnot(None))
+        .filter(Spool.tag_uid.is_(None))
+        .all()
+    ):
+        cloud = cloud_by_id.get(spool.bambu_spool_id)
+        if not cloud:
+            continue
+        tag = _extract_cloud_tag_uid(cloud)
+        if tag:
+            spool.tag_uid = tag
 
     # 3. Push local → cloud (create cloud records for local-only spools)
     for local_id in body.push_to_cloud:

--- a/filament_manager/backend/app/routers/filament_sync.py
+++ b/filament_manager/backend/app/routers/filament_sync.py
@@ -183,6 +183,14 @@ def _cloud_ams_slot_key(rec: dict) -> str | None:
     return f"ams{ams_id + 1}_tray{slot_id + 1}"
 
 
+def _cloud_updated_at(rec: dict) -> float:
+    """Epoch seconds from a cloud record's ``updatedAt`` (0.0 if absent/bad)."""
+    try:
+        return float(rec.get("updatedAt") or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def _bind_ams_slots_from_cloud(db: Session, cloud_by_id: dict[str, dict]) -> None:
     """Set ``ams_slot`` on linked spools directly from the cloud AMS position.
 
@@ -202,6 +210,29 @@ def _bind_ams_slots_from_cloud(db: Session, cloud_by_id: dict[str, dict]) -> Non
     if not printers_by_serial:
         return
 
+    # Resolve stale-flag collisions: Bambu Cloud sometimes leaves inPrinter=true on
+    # an OLD record after a spool is swapped out, so two records can claim the same
+    # (devId, slot). Keep only the most-recently-updated record per slot (the actual
+    # current occupant) and skip the stale older one(s) — newer deterministically wins.
+    groups: dict[tuple, list[dict]] = {}
+    for cloud in cloud_by_id.values():
+        slot_key = _cloud_ams_slot_key(cloud)
+        if slot_key is None:
+            continue
+        dev = str(cloud.get("devId") or "")
+        if dev in printers_by_serial:
+            groups.setdefault((dev, slot_key), []).append(cloud)
+    winner_id_by_slot: dict[tuple, object] = {}
+    for key, recs in groups.items():
+        recs.sort(key=_cloud_updated_at, reverse=True)
+        winner_id_by_slot[key] = recs[0].get("id")
+        for stale in recs[1:]:
+            log.info(
+                "filament sync: slot %s has a stale duplicate cloud record id=%s "
+                "(updatedAt=%s); keeping newer id=%s",
+                key[1], stale.get("id"), stale.get("updatedAt"), recs[0].get("id"),
+            )
+
     for spool in db.query(Spool).filter(Spool.bambu_spool_id.isnot(None)).all():
         cloud = cloud_by_id.get(spool.bambu_spool_id)
         if not cloud:
@@ -209,9 +240,12 @@ def _bind_ams_slots_from_cloud(db: Session, cloud_by_id: dict[str, dict]) -> Non
         slot_key = _cloud_ams_slot_key(cloud)
         if slot_key is None:
             continue
-        printer = printers_by_serial.get(str(cloud.get("devId") or ""))
+        dev = str(cloud.get("devId") or "")
+        printer = printers_by_serial.get(dev)
         if printer is None:
             continue  # spool loaded on a printer we don't track → skip
+        if winner_id_by_slot.get((dev, slot_key)) != cloud.get("id"):
+            continue  # stale duplicate for this slot — the newer record owns it
         full_key = f"{printer.name}:{slot_key}"
         if spool.ams_slot == full_key:
             continue

--- a/filament_manager/backend/app/routers/printers.py
+++ b/filament_manager/backend/app/routers/printers.py
@@ -76,6 +76,11 @@ async def get_ams_trays(printer_id: int, db: Session = Depends(get_db)):
         remain_val = td.get("remain")
         # Negative remain (typically -1) means "not tracked by AMS" — show nothing
         ha_remaining = str(round(remain_val, 1)) if remain_val is not None and remain_val >= 0 else None
+        # Physical RFID tag of the loaded spool. Real (16-hex, non-zero) for
+        # genuine Bambu spools; "" / all-zeros for third-party (no usable RFID).
+        tag_uid_raw = td.get("tag_uid")
+        tag_uid = str(tag_uid_raw).strip() if tag_uid_raw else None
+        has_real_tag = bool(tag_uid) and set(tag_uid) != {"0"}
         result.append({
             "slot_key":     slot_key,
             "ams_id":       u,
@@ -83,7 +88,9 @@ async def get_ams_trays(printer_id: int, db: Session = Depends(get_db)):
             "ha_material":  td.get("material") or None,
             "ha_color_hex": td.get("color"),
             "ha_remaining": ha_remaining,
+            "tag_uid":      tag_uid if has_real_tag else None,
             "spool":        SpoolOut.model_validate(spool).model_dump() if spool else None,
+            "spool_bound":  spool is not None,
         })
     return result
 
@@ -191,6 +198,22 @@ def assign_ams_tray(
         if spool.ams_slot and spool.ams_slot != full_key:
             previous_slot = spool.ams_slot
         spool.ams_slot = full_key
+
+        # If the tray currently reports a real RFID tag_uid, persist it onto the
+        # spool. This turns a one-time manual confirm into permanent auto-bind:
+        # future loads of this physical spool are re-bound deterministically by
+        # tag_uid (see ams_autobind). tag_uid is unique per physical spool, so
+        # clear it from any OTHER spool that may have claimed the same tag.
+        if p.bambu_serial:
+            from .. import bambu_cloud_client
+            detail = bambu_cloud_client.get_ams_detail_for_serial(p.bambu_serial)
+            tag_raw = (detail.get(slot_key) or {}).get("tag_uid")
+            tag_uid = str(tag_raw).strip() if tag_raw else ""
+            if tag_uid and set(tag_uid) != {"0"}:
+                db.query(Spool).filter(
+                    Spool.tag_uid == tag_uid, Spool.id != spool.id
+                ).update({"tag_uid": None})
+                spool.tag_uid = tag_uid
 
     db.commit()
     from .. import ha_publisher

--- a/filament_manager/backend/app/schemas.py
+++ b/filament_manager/backend/app/schemas.py
@@ -56,6 +56,7 @@ class SpoolUpdate(BaseModel):
     article_number: str | None = None
     last_dried_at: datetime | None = None
     ams_slot: str | None = None
+    tag_uid: str | None = None
     notes: str | None = None
     archived: bool | None = None
 

--- a/filament_manager/backend/app/schemas.py
+++ b/filament_manager/backend/app/schemas.py
@@ -73,6 +73,7 @@ class SpoolOut(SpoolBase):
     updated_at: datetime
     bambu_spool_id: str | None = None
     bambu_synced_at: datetime | None = None
+    tag_uid: str | None = None
 
 
 # ── PrintUsage ───────────────────────────────────────────────────────────────

--- a/filament_manager/backend/tests/test_ams_autobind.py
+++ b/filament_manager/backend/tests/test_ams_autobind.py
@@ -252,23 +252,65 @@ class TestAssignPersistsTagUid:
 
 
 # ---------------------------------------------------------------------------
-# Cloud RFID capture (filament_sync._extract_cloud_tag_uid) — what makes it automatic
+# Cloud-authoritative AMS slot binding (filament_sync) — the automatic path
 # ---------------------------------------------------------------------------
 
-class TestCloudRfidCapture:
-    @pytest.mark.parametrize("record,expected", [
-        ({"rfid": REAL_TAG}, REAL_TAG),
-        ({"tagUid": REAL_TAG}, REAL_TAG),
-        ({"tag_uid": REAL_TAG}, REAL_TAG),
-        ({"filamentTagUid": REAL_TAG}, REAL_TAG),
-        ({"tray_uid": REAL_TAG}, REAL_TAG),
-        ({"RFID": REAL_TAG}, REAL_TAG),
-        ({"id": "123", "filamentType": "PLA"}, None),        # no RFID key present
-        ({"rfid": ZERO_TAG}, None),                          # all-zeros → not a real tag
-        ({"rfid": ""}, None),                                # empty
-        ({"rfid": "   "}, None),                             # whitespace only
-        ({"rfid": None, "tagUid": REAL_TAG}, REAL_TAG),      # first key null → next wins
+class TestCloudSlotKey:
+    @pytest.mark.parametrize("rec,expected", [
+        ({"inPrinter": True, "amsId": 1, "slotId": 1}, "ams2_tray2"),      # PETG live sample
+        ({"inPrinter": True, "amsId": 128, "slotId": 0}, "ams129_tray1"),  # ABS live sample (AMS-HT)
+        ({"inPrinter": True, "amsId": 0, "slotId": 0}, "ams1_tray1"),
+        ({"inPrinter": True, "amsId": "2", "slotId": "3"}, "ams3_tray4"),  # numeric strings
+        ({"inPrinter": False, "amsId": 1, "slotId": 1}, None),             # not loaded
+        ({"amsId": 1, "slotId": 1}, None),                                 # no inPrinter flag
+        ({"inPrinter": True, "amsId": 254, "slotId": 0}, None),            # external-spool sentinel
+        ({"inPrinter": True, "amsId": 1, "slotId": 255}, None),            # sentinel slot
+        ({"inPrinter": True, "amsId": None, "slotId": 1}, None),           # unparseable
+        ({"inPrinter": True}, None),                                       # missing ids
     ])
-    def test_extract_cloud_tag_uid(self, record, expected):
-        from app.routers.filament_sync import _extract_cloud_tag_uid
-        assert _extract_cloud_tag_uid(record) == expected
+    def test_cloud_ams_slot_key(self, rec, expected):
+        from app.routers.filament_sync import _cloud_ams_slot_key
+        assert _cloud_ams_slot_key(rec) == expected
+
+
+class TestCloudSlotBind:
+    def test_binds_when_single_active_printer(self, session):
+        from app.routers.filament_sync import _bind_ams_slots_from_cloud
+        _mk_printer(session)  # one active printer "My Printer"
+        spool = _mk_spool(session, material="PLA")
+        spool.bambu_spool_id = "c1"
+        session.commit()
+        cloud_by_id = {"c1": {"id": "c1", "inPrinter": True, "amsId": 1, "slotId": 1}}
+
+        _bind_ams_slots_from_cloud(session, cloud_by_id)
+        session.commit()
+        session.refresh(spool)
+        assert spool.ams_slot == "My Printer:ams2_tray2"
+
+    def test_skips_when_multiple_printers(self, session):
+        """Ambiguous printer attribution → never guess (mirrors the whole fix)."""
+        from app.routers.filament_sync import _bind_ams_slots_from_cloud
+        _mk_printer(session, name="P1", serial="01P00A000000001")
+        _mk_printer(session, name="P2", serial="01P00A000000002")
+        spool = _mk_spool(session, material="PLA")
+        spool.bambu_spool_id = "c1"
+        session.commit()
+        cloud_by_id = {"c1": {"id": "c1", "inPrinter": True, "amsId": 1, "slotId": 1}}
+
+        _bind_ams_slots_from_cloud(session, cloud_by_id)
+        session.commit()
+        session.refresh(spool)
+        assert spool.ams_slot is None
+
+    def test_not_in_printer_leaves_slot_unset(self, session):
+        from app.routers.filament_sync import _bind_ams_slots_from_cloud
+        _mk_printer(session)
+        spool = _mk_spool(session, material="PLA")
+        spool.bambu_spool_id = "c1"
+        session.commit()
+        cloud_by_id = {"c1": {"id": "c1", "inPrinter": False, "amsId": 1, "slotId": 1}}
+
+        _bind_ams_slots_from_cloud(session, cloud_by_id)
+        session.commit()
+        session.refresh(spool)
+        assert spool.ams_slot is None

--- a/filament_manager/backend/tests/test_ams_autobind.py
+++ b/filament_manager/backend/tests/test_ams_autobind.py
@@ -75,11 +75,29 @@ class TestIsRealTagUid:
 
 
 # ---------------------------------------------------------------------------
-# First bind (single unambiguous candidate)
+# Exact RFID match ONLY — never guess by material/colour
 # ---------------------------------------------------------------------------
 
-class TestFirstBind:
-    def test_single_material_color_candidate_is_bound(self, session):
+class TestExactMatch:
+    def test_exact_tag_match_binds(self, session):
+        """A spool whose tag_uid was populated (from cloud sync or manual assign)
+        binds when that exact RFID appears in a tray."""
+        _mk_printer(session)
+        spool = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
+        spool.tag_uid = REAL_TAG
+        session.commit()
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 90}}
+
+        changed = _run_autobind(session, detail)
+
+        session.refresh(spool)
+        assert changed == 1
+        assert spool.ams_slot == "My Printer:ams1_tray1"
+
+    def test_material_color_match_does_NOT_bind(self, session):
+        """Regression: a spool matching material+colour but with NO tag_uid must
+        NEVER be auto-bound. Material/colour identifies a product, not a physical
+        spool — guessing by it stamped the wrong RFID onto records (the bug)."""
         _mk_printer(session)
         spool = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
         detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 90}}
@@ -87,36 +105,27 @@ class TestFirstBind:
         changed = _run_autobind(session, detail)
 
         session.refresh(spool)
-        assert changed == 1
-        assert spool.tag_uid == REAL_TAG
-        assert spool.ams_slot == "My Printer:ams1_tray1"
-
-    def test_ambiguous_multiple_candidates_not_bound(self, session):
-        """Two identical white PLA spools → ambiguous → nothing bound (safety)."""
-        _mk_printer(session)
-        s1 = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
-        s2 = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
-        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 90}}
-
-        changed = _run_autobind(session, detail)
-
-        session.refresh(s1); session.refresh(s2)
-        assert changed == 0
-        assert s1.tag_uid is None and s2.tag_uid is None
-        assert s1.ams_slot is None and s2.ams_slot is None
-
-    def test_zero_candidates_not_bound(self, session):
-        _mk_printer(session)
-        spool = _mk_spool(session, material="PETG", color_name="Black", color_hex="#000000")
-        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 90}}
-
-        changed = _run_autobind(session, detail)
-        session.refresh(spool)
         assert changed == 0
         assert spool.tag_uid is None
+        assert spool.ams_slot is None
+
+    def test_unknown_tag_is_noop(self, session):
+        """A real tag matching no spool's tag_uid → nothing happens, no error."""
+        _mk_printer(session)
+        spool = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
+        spool.tag_uid = REAL_TAG_2  # a DIFFERENT physical spool
+        session.commit()
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 90}}
+
+        changed = _run_autobind(session, detail)
+
+        session.refresh(spool)
+        assert changed == 0
+        assert spool.ams_slot is None
 
     def test_zero_tag_is_skipped(self, session):
-        """Third-party spool (all-zeros tag) → never auto-bound."""
+        """Third-party spool (all-zeros tag) → never auto-bound, even with an
+        exact material/colour spool present."""
         _mk_printer(session)
         spool = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
         detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": ZERO_TAG, "remain": 90}}
@@ -126,32 +135,6 @@ class TestFirstBind:
         assert changed == 0
         assert spool.tag_uid is None
         assert spool.ams_slot is None
-
-    def test_prefers_bambu_spool_id_and_color(self, session):
-        """When tray carries a bambu_spool_id it disambiguates two same-material spools."""
-        _mk_printer(session)
-        s1 = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF",
-                       bambu_spool_id="111")
-        s2 = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF",
-                       bambu_spool_id="222")
-        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF",
-                                 "bambu_spool_id": "222", "tag_uid": REAL_TAG, "remain": 90}}
-
-        changed = _run_autobind(session, detail)
-        session.refresh(s1); session.refresh(s2)
-        assert changed == 1
-        assert s2.tag_uid == REAL_TAG
-        assert s1.tag_uid is None
-
-    def test_empty_stock_spool_not_a_candidate(self, session):
-        _mk_printer(session)
-        spool = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF",
-                          current_weight_g=0.0)
-        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 0}}
-        changed = _run_autobind(session, detail)
-        session.refresh(spool)
-        assert changed == 0
-        assert spool.tag_uid is None
 
 
 # ---------------------------------------------------------------------------
@@ -266,3 +249,26 @@ class TestAssignPersistsTagUid:
         assert resp.status_code == 200
         got = client.get(f"/api/spools/{spool['id']}").json()
         assert got["tag_uid"] is None
+
+
+# ---------------------------------------------------------------------------
+# Cloud RFID capture (filament_sync._extract_cloud_tag_uid) — what makes it automatic
+# ---------------------------------------------------------------------------
+
+class TestCloudRfidCapture:
+    @pytest.mark.parametrize("record,expected", [
+        ({"rfid": REAL_TAG}, REAL_TAG),
+        ({"tagUid": REAL_TAG}, REAL_TAG),
+        ({"tag_uid": REAL_TAG}, REAL_TAG),
+        ({"filamentTagUid": REAL_TAG}, REAL_TAG),
+        ({"tray_uid": REAL_TAG}, REAL_TAG),
+        ({"RFID": REAL_TAG}, REAL_TAG),
+        ({"id": "123", "filamentType": "PLA"}, None),        # no RFID key present
+        ({"rfid": ZERO_TAG}, None),                          # all-zeros → not a real tag
+        ({"rfid": ""}, None),                                # empty
+        ({"rfid": "   "}, None),                             # whitespace only
+        ({"rfid": None, "tagUid": REAL_TAG}, REAL_TAG),      # first key null → next wins
+    ])
+    def test_extract_cloud_tag_uid(self, record, expected):
+        from app.routers.filament_sync import _extract_cloud_tag_uid
+        assert _extract_cloud_tag_uid(record) == expected

--- a/filament_manager/backend/tests/test_ams_autobind.py
+++ b/filament_manager/backend/tests/test_ams_autobind.py
@@ -1,0 +1,268 @@
+"""
+Tests for RFID tag_uid AMS auto-bind (app.ams_autobind) and the assign
+endpoint's tag_uid persistence.
+
+The auto-bind logic is exercised against the in-memory DB via the `session`
+fixture with `bambu_cloud_client.get_ams_detail_for_serial` monkeypatched to
+return a synthetic AMS tray snapshot. The assign endpoint is exercised via the
+HTTP `client`.
+"""
+import pytest
+from unittest.mock import patch
+
+from app import ams_autobind, bambu_cloud_client
+from app.models import PrinterConfig, Spool
+from tests.conftest import make_spool_payload
+
+
+REAL_TAG = "4767E20300000100"
+REAL_TAG_2 = "4767E20300000200"
+ZERO_TAG = "0000000000000000"
+SERIAL = "01P00A000000001"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mk_printer(session, name="My Printer", serial=SERIAL, active=True):
+    p = PrinterConfig(name=name, bambu_serial=serial, is_active=active, bambu_source="cloud")
+    session.add(p)
+    session.commit()
+    session.refresh(p)
+    return p
+
+
+def _mk_spool(session, **kw):
+    data = make_spool_payload(**kw)
+    s = Spool(**data)
+    session.add(s)
+    session.commit()
+    session.refresh(s)
+    return s
+
+
+def _run_autobind(session, detail):
+    """Patch the AMS cache + SessionLocal so autobind uses the test DB session."""
+    class _Factory:
+        def __call__(self):
+            return session
+    # autobind opens its own SessionLocal() and closes it — patch to hand back
+    # the test session and no-op close so assertions can read the same rows.
+    orig_close = session.close
+    session.close = lambda: None
+    try:
+        with patch.object(bambu_cloud_client, "get_ams_detail_for_serial", return_value=detail), \
+             patch.object(ams_autobind, "SessionLocal", _Factory()), \
+             patch("app.ha_publisher.trigger", lambda: None):
+            return ams_autobind.autobind_from_ams_cache(SERIAL)
+    finally:
+        session.close = orig_close
+
+
+# ---------------------------------------------------------------------------
+# _is_real_tag_uid
+# ---------------------------------------------------------------------------
+
+class TestIsRealTagUid:
+    @pytest.mark.parametrize("val", [None, "", "   ", ZERO_TAG, "000", "0"])
+    def test_rejects_empty_and_zeros(self, val):
+        assert ams_autobind._is_real_tag_uid(val) is False
+
+    @pytest.mark.parametrize("val", [REAL_TAG, "4767E20300000100", "0000000000000001"])
+    def test_accepts_real(self, val):
+        assert ams_autobind._is_real_tag_uid(val) is True
+
+
+# ---------------------------------------------------------------------------
+# First bind (single unambiguous candidate)
+# ---------------------------------------------------------------------------
+
+class TestFirstBind:
+    def test_single_material_color_candidate_is_bound(self, session):
+        _mk_printer(session)
+        spool = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 90}}
+
+        changed = _run_autobind(session, detail)
+
+        session.refresh(spool)
+        assert changed == 1
+        assert spool.tag_uid == REAL_TAG
+        assert spool.ams_slot == "My Printer:ams1_tray1"
+
+    def test_ambiguous_multiple_candidates_not_bound(self, session):
+        """Two identical white PLA spools → ambiguous → nothing bound (safety)."""
+        _mk_printer(session)
+        s1 = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
+        s2 = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 90}}
+
+        changed = _run_autobind(session, detail)
+
+        session.refresh(s1); session.refresh(s2)
+        assert changed == 0
+        assert s1.tag_uid is None and s2.tag_uid is None
+        assert s1.ams_slot is None and s2.ams_slot is None
+
+    def test_zero_candidates_not_bound(self, session):
+        _mk_printer(session)
+        spool = _mk_spool(session, material="PETG", color_name="Black", color_hex="#000000")
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 90}}
+
+        changed = _run_autobind(session, detail)
+        session.refresh(spool)
+        assert changed == 0
+        assert spool.tag_uid is None
+
+    def test_zero_tag_is_skipped(self, session):
+        """Third-party spool (all-zeros tag) → never auto-bound."""
+        _mk_printer(session)
+        spool = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": ZERO_TAG, "remain": 90}}
+
+        changed = _run_autobind(session, detail)
+        session.refresh(spool)
+        assert changed == 0
+        assert spool.tag_uid is None
+        assert spool.ams_slot is None
+
+    def test_prefers_bambu_spool_id_and_color(self, session):
+        """When tray carries a bambu_spool_id it disambiguates two same-material spools."""
+        _mk_printer(session)
+        s1 = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF",
+                       bambu_spool_id="111")
+        s2 = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF",
+                       bambu_spool_id="222")
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF",
+                                 "bambu_spool_id": "222", "tag_uid": REAL_TAG, "remain": 90}}
+
+        changed = _run_autobind(session, detail)
+        session.refresh(s1); session.refresh(s2)
+        assert changed == 1
+        assert s2.tag_uid == REAL_TAG
+        assert s1.tag_uid is None
+
+    def test_empty_stock_spool_not_a_candidate(self, session):
+        _mk_printer(session)
+        spool = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF",
+                          current_weight_g=0.0)
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 0}}
+        changed = _run_autobind(session, detail)
+        session.refresh(spool)
+        assert changed == 0
+        assert spool.tag_uid is None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic re-bind (tag already known)
+# ---------------------------------------------------------------------------
+
+class TestReBind:
+    def test_known_tag_rebinds_to_new_slot(self, session):
+        _mk_printer(session)
+        spool = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
+        spool.tag_uid = REAL_TAG
+        spool.ams_slot = "My Printer:ams1_tray1"
+        session.commit()
+
+        # Same physical spool now loaded in tray 3
+        detail = {"ams1_tray3": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 80}}
+        changed = _run_autobind(session, detail)
+
+        session.refresh(spool)
+        assert changed == 1
+        assert spool.ams_slot == "My Printer:ams1_tray3"
+
+    def test_known_tag_same_slot_no_change(self, session):
+        _mk_printer(session)
+        spool = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
+        spool.tag_uid = REAL_TAG
+        spool.ams_slot = "My Printer:ams1_tray1"
+        session.commit()
+
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 80}}
+        changed = _run_autobind(session, detail)
+        session.refresh(spool)
+        assert changed == 0
+        assert spool.ams_slot == "My Printer:ams1_tray1"
+
+    def test_rebind_clears_slot_from_other_spool(self, session):
+        """A tag_uid is unique → a second spool wrongly on the slot is cleared."""
+        _mk_printer(session)
+        bound = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
+        bound.tag_uid = REAL_TAG
+        session.commit()
+        squatter = _mk_spool(session, material="PLA", color_name="Blue", color_hex="#0000FF")
+        squatter.ams_slot = "My Printer:ams1_tray5"
+        session.commit()
+
+        detail = {"ams1_tray5": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 70}}
+        changed = _run_autobind(session, detail)
+
+        session.refresh(bound); session.refresh(squatter)
+        assert changed == 1
+        assert bound.ams_slot == "My Printer:ams1_tray5"
+        assert squatter.ams_slot is None
+
+
+# ---------------------------------------------------------------------------
+# Inactive printer / no data
+# ---------------------------------------------------------------------------
+
+class TestGuards:
+    def test_inactive_printer_no_bind(self, session):
+        _mk_printer(session, active=False)
+        spool = _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": REAL_TAG, "remain": 90}}
+        changed = _run_autobind(session, detail)
+        session.refresh(spool)
+        assert changed == 0
+        assert spool.tag_uid is None
+
+    def test_no_real_tag_short_circuits(self, session):
+        _mk_printer(session)
+        _mk_spool(session, material="PLA", color_name="White", color_hex="#FFFFFF")
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FFFFFF", "tag_uid": ZERO_TAG}}
+        assert _run_autobind(session, detail) == 0
+
+
+# ---------------------------------------------------------------------------
+# Assign endpoint persists tag_uid
+# ---------------------------------------------------------------------------
+
+class TestAssignPersistsTagUid:
+    def test_assign_stores_tray_tag_uid_on_spool(self, client):
+        r = client.post("/api/printers", json={"name": "My Printer", "bambu_serial": SERIAL})
+        printer = r.json()
+        spool = client.post("/api/spools", json=make_spool_payload()).json()
+
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FF0000", "tag_uid": REAL_TAG, "remain": 90}}
+        with patch("app.bambu_cloud_client.get_ams_detail_for_serial", return_value=detail), \
+             patch("app.bambu_cloud_client.register_printer"), \
+             patch("app.ha_publisher.trigger"):
+            resp = client.post(
+                f"/api/printers/{printer['id']}/ams/ams1_tray1/assign",
+                json={"spool_id": spool["id"]},
+            )
+        assert resp.status_code == 200
+        got = client.get(f"/api/spools/{spool['id']}").json()
+        assert got["ams_slot"] == "My Printer:ams1_tray1"
+        assert got["tag_uid"] == REAL_TAG
+
+    def test_assign_ignores_zero_tag(self, client):
+        r = client.post("/api/printers", json={"name": "My Printer", "bambu_serial": SERIAL})
+        printer = r.json()
+        spool = client.post("/api/spools", json=make_spool_payload()).json()
+
+        detail = {"ams1_tray1": {"material": "PLA", "color": "#FF0000", "tag_uid": ZERO_TAG, "remain": 90}}
+        with patch("app.bambu_cloud_client.get_ams_detail_for_serial", return_value=detail), \
+             patch("app.bambu_cloud_client.register_printer"), \
+             patch("app.ha_publisher.trigger"):
+            resp = client.post(
+                f"/api/printers/{printer['id']}/ams/ams1_tray1/assign",
+                json={"spool_id": spool["id"]},
+            )
+        assert resp.status_code == 200
+        got = client.get(f"/api/spools/{spool['id']}").json()
+        assert got["tag_uid"] is None

--- a/filament_manager/backend/tests/test_ams_autobind.py
+++ b/filament_manager/backend/tests/test_ams_autobind.py
@@ -330,6 +330,30 @@ class TestCloudSlotBind:
         session.refresh(spool)
         assert spool.ams_slot is None
 
+    def test_stale_duplicate_slot_newer_wins(self, session):
+        """Bambu leaves inPrinter=true on a swapped-out record → two records claim
+        the same slot. Bind the newer (max updatedAt); skip the stale older one.
+        (Real collision from prod: ams4_tray3, white current vs blue stale.)"""
+        from app.routers.filament_sync import _bind_ams_slots_from_cloud
+        _mk_printer(session, name="Garage", serial="DEV1")
+        newer = _mk_spool(session, material="PLA", color_hex="#FFFFFF")
+        newer.bambu_spool_id = "1827160"
+        older = _mk_spool(session, material="PLA", color_hex="#0A2989")
+        older.bambu_spool_id = "593855"
+        session.commit()
+        cloud_by_id = {
+            "1827160": {"id": "1827160", "inPrinter": True, "amsId": 3, "slotId": 2,
+                        "devId": "DEV1", "updatedAt": 1782177080},  # newer = current
+            "593855":  {"id": "593855", "inPrinter": True, "amsId": 3, "slotId": 2,
+                        "devId": "DEV1", "updatedAt": 1782162701},  # older = stale
+        }
+
+        _bind_ams_slots_from_cloud(session, cloud_by_id)
+        session.commit()
+        session.refresh(newer); session.refresh(older)
+        assert newer.ams_slot == "Garage:ams4_tray3"
+        assert older.ams_slot is None
+
 
 class TestTagUidManualClear:
     """SpoolUpdate now carries tag_uid so a stale/wrong stamp can be cleared or

--- a/filament_manager/backend/tests/test_ams_autobind.py
+++ b/filament_manager/backend/tests/test_ams_autobind.py
@@ -274,28 +274,43 @@ class TestCloudSlotKey:
 
 
 class TestCloudSlotBind:
-    def test_binds_when_single_active_printer(self, session):
+    def test_binds_by_devid_match(self, session):
         from app.routers.filament_sync import _bind_ams_slots_from_cloud
-        _mk_printer(session)  # one active printer "My Printer"
+        _mk_printer(session)  # "My Printer", serial SERIAL
         spool = _mk_spool(session, material="PLA")
         spool.bambu_spool_id = "c1"
         session.commit()
-        cloud_by_id = {"c1": {"id": "c1", "inPrinter": True, "amsId": 1, "slotId": 1}}
+        cloud_by_id = {"c1": {"id": "c1", "inPrinter": True, "amsId": 1, "slotId": 1, "devId": SERIAL}}
 
         _bind_ams_slots_from_cloud(session, cloud_by_id)
         session.commit()
         session.refresh(spool)
         assert spool.ams_slot == "My Printer:ams2_tray2"
 
-    def test_skips_when_multiple_printers(self, session):
-        """Ambiguous printer attribution → never guess (mirrors the whole fix)."""
+    def test_binds_correct_printer_when_multiple(self, session):
+        """devId scopes each bind to the owning printer — precise, no guard needed."""
         from app.routers.filament_sync import _bind_ams_slots_from_cloud
-        _mk_printer(session, name="P1", serial="01P00A000000001")
-        _mk_printer(session, name="P2", serial="01P00A000000002")
+        _mk_printer(session, name="Garage", serial="AAA")
+        _mk_printer(session, name="Office", serial="BBB")
         spool = _mk_spool(session, material="PLA")
         spool.bambu_spool_id = "c1"
         session.commit()
-        cloud_by_id = {"c1": {"id": "c1", "inPrinter": True, "amsId": 1, "slotId": 1}}
+        # ABS-shaped record (amsId 128 → ams129) loaded on the Office printer
+        cloud_by_id = {"c1": {"id": "c1", "inPrinter": True, "amsId": 128, "slotId": 0, "devId": "BBB"}}
+
+        _bind_ams_slots_from_cloud(session, cloud_by_id)
+        session.commit()
+        session.refresh(spool)
+        assert spool.ams_slot == "Office:ams129_tray1"
+
+    def test_skips_untracked_device(self, session):
+        """A spool loaded on a printer we don't track is left alone (never guess)."""
+        from app.routers.filament_sync import _bind_ams_slots_from_cloud
+        _mk_printer(session, serial="AAA")
+        spool = _mk_spool(session, material="PLA")
+        spool.bambu_spool_id = "c1"
+        session.commit()
+        cloud_by_id = {"c1": {"id": "c1", "inPrinter": True, "amsId": 1, "slotId": 1, "devId": "UNKNOWN"}}
 
         _bind_ams_slots_from_cloud(session, cloud_by_id)
         session.commit()
@@ -308,9 +323,24 @@ class TestCloudSlotBind:
         spool = _mk_spool(session, material="PLA")
         spool.bambu_spool_id = "c1"
         session.commit()
-        cloud_by_id = {"c1": {"id": "c1", "inPrinter": False, "amsId": 1, "slotId": 1}}
+        cloud_by_id = {"c1": {"id": "c1", "inPrinter": False, "amsId": 1, "slotId": 1, "devId": SERIAL}}
 
         _bind_ams_slots_from_cloud(session, cloud_by_id)
         session.commit()
         session.refresh(spool)
         assert spool.ams_slot is None
+
+
+class TestTagUidManualClear:
+    """SpoolUpdate now carries tag_uid so a stale/wrong stamp can be cleared or
+    corrected via PATCH (previously the field was silently dropped)."""
+    def test_patch_sets_and_clears_tag_uid(self, client):
+        spool = client.post("/api/spools", json=make_spool_payload()).json()
+
+        r = client.patch(f"/api/spools/{spool['id']}", json={"tag_uid": REAL_TAG})
+        assert r.status_code == 200
+        assert r.json()["tag_uid"] == REAL_TAG
+
+        r = client.patch(f"/api/spools/{spool['id']}", json={"tag_uid": None})
+        assert r.status_code == 200
+        assert r.json()["tag_uid"] is None

--- a/filament_manager/frontend/src/locales/de.json
+++ b/filament_manager/frontend/src/locales/de.json
@@ -435,6 +435,7 @@
       "autoMatchTray": "Beste Übereinstimmung",
       "autoMatchNone": "Keine passende Spule im Inventar",
       "autoMatchResult": "{{count}} Fach/Fächer automatisch zugeordnet",
+      "assignSpool": "Zuweisen",
       "energyTracking": "Energieverfolgung",
       "energySensor": "Energiesensor (HA-Entity-ID)",
       "energySensorHint": "Kumulativer kWh-Sensor, z. B. von einem Shelly-Plug. Wird beim Druckstart und -ende ausgelesen, um den Verbrauch zu berechnen.",

--- a/filament_manager/frontend/src/locales/en.json
+++ b/filament_manager/frontend/src/locales/en.json
@@ -435,6 +435,7 @@
       "autoMatchTray": "Best match",
       "autoMatchNone": "No matching spool in inventory",
       "autoMatchResult": "Auto-matched {{count}} tray(s)",
+      "assignSpool": "Assign",
       "energyTracking": "Energy Tracking",
       "energySensor": "Energy Sensor (HA entity ID)",
       "energySensorHint": "Cumulative kWh sensor, e.g. from a Shelly plug. Read at print start and end to calculate consumption.",

--- a/filament_manager/frontend/src/locales/es.json
+++ b/filament_manager/frontend/src/locales/es.json
@@ -435,6 +435,7 @@
       "autoMatchTray": "Mejor coincidencia",
       "autoMatchNone": "No hay bobina coincidente en el inventario",
       "autoMatchResult": "{{count}} bandeja(s) asignada(s) automáticamente",
+      "assignSpool": "Asignar",
       "energyTracking": "Seguimiento de energía",
       "energySensor": "Sensor de energía (ID de entidad HA)",
       "energySensorHint": "Sensor kWh acumulativo, p. ej. de un enchufe Shelly. Se lee al inicio y al final de la impresión para calcular el consumo.",

--- a/filament_manager/frontend/src/pages/Settings.tsx
+++ b/filament_manager/frontend/src/pages/Settings.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { api } from '../api'
 import type { PrinterConfig, AMSTray, Spool, BrandSpoolWeight, FilamentSubtype, BambuCloudStatus, BambuCloudDevice, FilamentCatalog } from '../types'
-import { Plus, Trash2, X, RefreshCw, CheckCircle, AlertCircle, Pencil, ChevronDown, ChevronUp, ChevronsUpDown, Download, Upload, Wifi, WifiOff, Sparkles } from 'lucide-react'
+import { Plus, Trash2, X, RefreshCw, CheckCircle, AlertCircle, Pencil, ChevronDown, ChevronUp, ChevronsUpDown, Download, Upload, Wifi, WifiOff, Sparkles, Tag } from 'lucide-react'
 import Modal from '../components/Modal'
 import BambuCloudSection from '../components/BambuCloudSection'
 import FilamentSyncSection from '../components/FilamentSyncSection'
@@ -511,6 +511,15 @@ function AMSTrayRow({
 }) {
   const { t } = useTranslation()
   const selectedId = tray.spool?.id ?? null
+  // Short-form of the physical RFID tag (last 4 hex) for a compact display.
+  const tagShort = tray.tag_uid ? tray.tag_uid.slice(-4).toUpperCase() : null
+  // A genuine spool is physically loaded (real RFID) but nothing is tracked to
+  // this tray yet — surface a one-tap assign so a single confirm makes future
+  // loads auto-bind (the assign endpoint persists the tag_uid).
+  const bestMatch = tray.ha_material && tray.ha_color_hex
+    ? findBestSpoolMatch(tray, spools, excludeIds)
+    : null
+  const needsAssign = !!tray.tag_uid && !tray.spool_bound
 
   return (
     <div className="flex items-center gap-2 bg-surface-3/40 rounded-lg px-3 py-2">
@@ -528,6 +537,14 @@ function AMSTrayRow({
         <span className="text-xs text-gray-500 truncate">
           {tray.ha_material ?? '—'}
         </span>
+        {tagShort && (
+          <span
+            className="inline-flex items-center gap-0.5 text-[9px] font-mono text-emerald-400/80 shrink-0"
+            title={`RFID tag_uid: ${tray.tag_uid}`}
+          >
+            <Tag size={8} />{tagShort}
+          </span>
+        )}
       </div>
 
       <span className="text-xs text-gray-500 w-10 shrink-0 text-right">
@@ -557,9 +574,29 @@ function AMSTrayRow({
           ))}
       </select>
 
+      {/* One-tap assign for a genuine (RFID-tagged) spool with nothing tracked
+          to this tray yet. Assigning persists the tag_uid so future loads
+          auto-bind. Uses the existing best-match; falls back to disabled. */}
+      {needsAssign && (
+        <button
+          onClick={() => bestMatch && onAssign(bestMatch.id)}
+          disabled={!bestMatch || saving}
+          title={bestMatch
+            ? `${t('settings.printers.autoMatchTray')}: ${bestMatch.custom_id != null ? `#${bestMatch.custom_id} ` : ''}${bestMatch.brand} ${bestMatch.material} · ${bestMatch.color_name}`
+            : t('settings.printers.autoMatchNone')}
+          className={`shrink-0 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium ${
+            bestMatch
+              ? 'bg-emerald-600/20 text-emerald-300 hover:bg-emerald-600/30'
+              : 'bg-surface-3 text-gray-500 cursor-not-allowed'
+          }`}
+        >
+          <Tag size={9} />{t('settings.printers.assignSpool')}
+        </button>
+      )}
+
       {/* Auto-match button — only when printer reports material+color for this tray */}
       {tray.ha_material && tray.ha_color_hex && (() => {
-        const match = findBestSpoolMatch(tray, spools, excludeIds)
+        const match = bestMatch
         const alreadyOptimal = match != null && tray.spool?.id === match.id
         return (
           <button

--- a/filament_manager/frontend/src/types.ts
+++ b/filament_manager/frontend/src/types.ts
@@ -30,6 +30,7 @@ export interface Spool {
   updated_at: string
   bambu_spool_id: string | null
   bambu_synced_at: string | null
+  tag_uid: string | null
 }
 
 export type SyncMode = 'off' | 'pull' | 'push' | 'bidirectional'
@@ -262,7 +263,9 @@ export interface AMSTray {
   ha_material: string | null
   ha_color_hex: string | null
   ha_remaining: string | null
+  tag_uid: string | null       // physical RFID tag (16-hex); null for third-party spools
   spool: Spool | null
+  spool_bound: boolean         // true when a tracked spool is assigned to this tray
 }
 
 


### PR DESCRIPTION
## What & why

When a genuine Bambu spool is physically loaded into an AMS tray, the printer reads its RFID `tag_uid` (a 16-hex string, unique per physical spool). This PR uses that tag to **deterministically bind the tracked spool to the tray** — i.e. it sets the spool's `ams_slot` — so the *existing* auto-deduct logic fires against the **correct physical spool**, even when a user owns many spools of the same material + colour (e.g. 11 white PLA Basic). Material+colour alone is not a safe unique key; `tag_uid` is.

Today the spool↔tray binding is manual (`POST /printers/{id}/ams/{slot_key}/assign`). This adds automatic, physical-identity-based binding on load, plus a one-time manual-confirm path that upgrades to permanent auto-bind.

## Design

The AMS MQTT tray objects carry a real, non-zero `tag_uid` per genuine Bambu spool; third-party/generic spools report all-zeros (`"0000000000000000"`) or empty (no usable RFID).

- **`bambu_cloud_client._parse_ams_into_cache`** now captures `tag_uid` into each cached slot dict (surfaces via `get_ams_detail_for_serial`). The MQTT message path calls the binder whenever fresh AMS tray data arrives.
- **New `app/ams_autobind.py`** — the binder. For each occupied tray with a **real** `tag_uid`:
  - If a `Spool` already has `tag_uid == tray.tag_uid` → ensure its `ams_slot` equals this tray (deterministic re-bind on every load).
  - Else, if no spool has that tag yet → attempt a first bind among spools **not yet tag-bound**, matching by `(bambu_spool_id AND colour)` or, absent a cloud id, `(material AND colour)`. Bind **only** if there is **exactly one** unambiguous candidate.
- **`Spool.tag_uid`** — new nullable, indexed column.
- **`main.py`** — guarded, idempotent startup migration (`ADD COLUMN` only if absent + `CREATE INDEX IF NOT EXISTS`), mirroring the existing migration pattern.
- **`schemas.SpoolOut`** exposes `tag_uid`.
- **`routers/printers.get_ams_trays`** returns each tray's `tag_uid` (real tags only) and a `spool_bound` flag.
- **The assign endpoint** now also persists the tray's real `tag_uid` onto the assigned spool — so a **one-time manual confirm** turns every future load of that physical spool into an automatic re-bind.

## 🔴 Safety — never auto-bind ambiguously

The only automatic actions are:
1. **Deterministic re-bind** of an already-known `tag_uid` to its current tray.
2. **First bind only when exactly one** not-yet-tag-bound spool matches.

Zero **or** multiple candidates → **nothing is bound**; the tray is left for a one-tap manual "Assign spool" in the UI. Empty / all-zeros tags (third-party spools) are skipped entirely. A `tag_uid` is unique per physical spool, so any *other* spool claiming the same slot is cleared before binding (race / duplicate-bind guard). This guarantees auto-deduct can never deduct from the wrong physical spool.

## Migrations

Guarded and idempotent — safe to run repeatedly on existing DBs; won't crash if the column already exists.

## Frontend (React + TS)

- `types`: `AMSTray` gains `tag_uid` + `spool_bound`; `Spool` gains `tag_uid`.
- Settings AMS tray view: a short RFID tag badge, plus a one-tap **Assign spool** affordance for a tagged tray with no bound spool (uses the existing assign endpoint, which now stores `tag_uid`). i18n added for en/de/es.

## Testing

- **22 new backend tests** covering: real-vs-zero tag detection, single-candidate first bind, ambiguous/zero-candidate no-bind, `bambu_spool_id` disambiguation, empty-stock exclusion, deterministic re-bind, slot-clear-from-other-spool, inactive-printer guard, and the assign-endpoint `tag_uid` persistence (including zero-tag ignore).
- Full backend suite: **264 passing** (was 242).
- Frontend: `tsc --noEmit` and `vite build` both pass; no compiled `.js` committed.